### PR TITLE
DOMNodeInserted removed

### DIFF
--- a/resources/views/captcha.blade.php
+++ b/resources/views/captcha.blade.php
@@ -28,9 +28,18 @@ $('#captcha-img').click(function () {
     $(this).attr('src', $(this).attr('src').replace(/\?random=.*$/, '?random=' + Math.random()));
 });
 
-$('#captcha .with-errors').bind('DOMNodeInserted', function () {
-    if ($('#captcha-input').val() !== '' && $(this).html().length > 0) {
-        $("#captcha-img").trigger("click");
-    }
-});
+const observer = new MutationObserver(function(mutationsList) {
+    for(let mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+            if ($('#captcha-input').val() !== '' && $('#captcha .with-errors').html().length > 0) {
+                $("#captcha-img").trigger("click");
+            }
+        }
+     }
+    });
+observer.observe($('#captcha .with-errors')[0], {
+        attributes: false,
+        childList: true,
+        subtree: true
+    });
 })();


### PR DESCRIPTION
### **User description**
DOMNodeInserted removed


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Removed the deprecated `DOMNodeInserted` event binding from the captcha script.
- Introduced `MutationObserver` to monitor changes in the DOM, specifically for the `#captcha .with-errors` element.
- This change ensures compatibility with newer versions of Chrome and Edge that no longer support `DOMNodeInserted`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>captcha.blade.php</strong><dd><code>Replace deprecated DOMNodeInserted with MutationObserver</code>&nbsp; </dd></summary>
<hr>

resources/views/captcha.blade.php

<li>Removed deprecated <code>DOMNodeInserted</code> event binding.<br> <li> Implemented <code>MutationObserver</code> to handle DOM changes.<br> <li> Observes changes in the <code>#captcha .with-errors</code> element.<br>


</details>


  </td>
  <td><a href="https://github.com/guanguans/dcat-login-captcha/pull/53/files#diff-9a94bae4f5e5a89a21851f9ee562504de42945bf291bcb72c4a5af06176b2e06">+14/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

